### PR TITLE
permission to get lambda resources

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -59,6 +59,7 @@ provider:
         - "application-autoscaling:*"
         - "autoscaling:*"
         - "apigateway:*"
+        - "lambda:Get*"
         - "lambda:Delete*"
         - "glue:Delete*"
         - "iam:DetachRolePolicy"


### PR DESCRIPTION
StackJanitor is not able to clean some of the lambda deployments because of the limited permission with lambda resources. Just adding get* to the list of permissions