### PR TITLE
Delete retry function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ However, If stack resources remain unused for certain period of time, TTL expira
 
 ![StackJanitor Architecture](./img/StackJanitor-git.jpg "StackJanitor Architecture")
 
+It's good to note that the actual CloudFormation delete is always done by the
+`./src/handlers/deleteCloudFormationStack.ts` function AFTER the DynamoDB
+stream for expired/deleted records.
+
+As the data flow will create another cloudtrail event with the 'DeleteStack'
+operation, the lambda function will be invoked a second time but nothing
+will happen.
+
 ## Installation
 
 1. Clone the repo.

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,5 +1,5 @@
 service:
-  name: StackJanitor
+  name: StackJanitor${self:custom.NAME_SUFFIX}
 
 # Add the serverless-webpack plugin
 plugins:
@@ -11,7 +11,8 @@ custom:
   DYNAMO_DB_TABLE: stackJanitorTable
   DEFAULT_EXPIRATION_PERIOD: 604800 # 604800 seconds === 7 days
   DEFAULT_REGION: "ap-southeast-2"
-  MAX_CLEANUP_RETRY: 10 # maximum number of retries before abandoning deletion
+  MAX_CLEANUP_RETRY: 5 # maximum number of retries before abandoning deletion
+  NAME_SUFFIX: ${env:NAME_SUFFIX}
 
 provider:
   name: aws
@@ -35,7 +36,7 @@ provider:
         - "dynamodb:PutItem"
         - "dynamodb:UpdateItem"
         - "dynamodb:DeleteItem"
-      Resource: "arn:aws:dynamodb:*:*:table/${self:custom.DYNAMO_DB_TABLE}"
+      Resource: "arn:aws:dynamodb:*:*:table/${self:custom.DYNAMO_DB_TABLE}${self:custom.NAME_SUFFIX}"
     - Effect: "Allow"
       Action:
         - "dynamodb:List*"
@@ -85,7 +86,7 @@ resources:
       DeletionPolicy: Retain
       UpdateReplacePolicy: Retain
       Properties:
-        TableName: ${self:custom.DYNAMO_DB_TABLE}
+        TableName: ${self:custom.DYNAMO_DB_TABLE}${self:custom.NAME_SUFFIX}
         AttributeDefinitions:
           - AttributeName: stackName
             AttributeType: S
@@ -116,7 +117,7 @@ functions:
   monitorCloudFormationStack:
     handler: src/handlers/monitorCloudFormationStack.index
     environment:
-      DEFAULT_DYNAMODB_TABLE: ${self:custom.DYNAMO_DB_TABLE}
+      DEFAULT_DYNAMODB_TABLE: ${self:custom.DYNAMO_DB_TABLE}${self:custom.NAME_SUFFIX}
       DEFAULT_EXPIRATION_PERIOD: ${self:custom.DEFAULT_EXPIRATION_PERIOD}
       DEFAULT_REGION: ${self:custom.DEFAULT_REGION}
       MAX_CLEANUP_RETRY: ${self:custom.MAX_CLEANUP_RETRY}
@@ -130,6 +131,11 @@ functions:
 
   deleteCloudFormationStack:
     handler: src/handlers/deleteCloudFormationStack.index
+    environment:
+      DEFAULT_DYNAMODB_TABLE: ${self:custom.DYNAMO_DB_TABLE}${self:custom.NAME_SUFFIX}
+      DEFAULT_EXPIRATION_PERIOD: ${self:custom.DEFAULT_EXPIRATION_PERIOD}
+      DEFAULT_REGION: ${self:custom.DEFAULT_REGION}
+      MAX_CLEANUP_RETRY: ${self:custom.MAX_CLEANUP_RETRY}
     events:
       - stream:
           type: dynamodb
@@ -139,7 +145,7 @@ functions:
 stepFunctions:
   stateMachines:
     StackJanitor:
-      name: StackJanitorStateMachine
+      name: StackJanitorStateMachine${self:custom.NAME_SUFFIX}
       definition:
         Comment: "StackJanitor State Machine"
         StartAt: logCloudFormationStack

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ custom:
   DYNAMO_DB_TABLE: stackJanitorTable
   DEFAULT_EXPIRATION_PERIOD: 604800 # 604800 seconds === 7 days
   DEFAULT_REGION: "ap-southeast-2"
-  MAX_CLEANUP_RETRY: 5 # maximum number of retries before abandoning deletion
+  MAX_CLEANUP_RETRY: 2 # maximum number of retries before abandoning deletion
   NAME_SUFFIX: ${env:NAME_SUFFIX}
 
 provider:

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,8 +9,9 @@ plugins:
 
 custom:
   DYNAMO_DB_TABLE: stackJanitorTable
-  DEFAULT_EXPIRATION_PERIOD: 604800 #seconds
+  DEFAULT_EXPIRATION_PERIOD: 604800 # 604800 seconds === 7 days
   DEFAULT_REGION: "ap-southeast-2"
+  MAX_CLEANUP_RETRY: 10 # maximum number of retries before abandoning deletion
 
 provider:
   name: aws
@@ -48,6 +49,7 @@ provider:
       Resource: "*"
     - Effect: "Allow"
       Action:
+        - "elasticache:Delete*"
         - "ec2:*"
         - "s3:*"
         - "ecs:*"
@@ -116,6 +118,7 @@ functions:
       DEFAULT_DYNAMODB_TABLE: ${self:custom.DYNAMO_DB_TABLE}
       DEFAULT_EXPIRATION_PERIOD: ${self:custom.DEFAULT_EXPIRATION_PERIOD}
       DEFAULT_REGION: ${self:custom.DEFAULT_REGION}
+      MAX_CLEANUP_RETRY: ${self:custom.MAX_CLEANUP_RETRY}
 
   gitHook:
     handler: src/handlers/gitHook.index

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ const config = {
     process.env.DEFAULT_DYNAMODB_TABLE || "stackJanitorTable",
   DEFAULT_EXPIRATION_PERIOD:
     process.env.DEFAULT_EXPIRATION_PERIOD || SEVEN_DAYS,
-  MAX_CLEANUP_RETRY: process.env.MAX_CLEANUP_RETRY || 10,
+  MAX_CLEANUP_RETRY: process.env.MAX_CLEANUP_RETRY || 5,
   DELETE_INTERVAL
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,14 @@
 const SEVEN_DAYS = 7 * 24 * 60 * 60;
+const DELETE_INTERVAL = 300; // 300 seconds = 5 mins
 
 const config = {
   DEFAULT_REGION: process.env.DEFAULT_REGION || "ap-southeast-2",
   DEFAULT_DYNAMODB_TABLE:
     process.env.DEFAULT_DYNAMODB_TABLE || "stackJanitorTable",
-  DEFAULT_EXPIRATION_PERIOD: process.env.DEFAULT_EXPIRATION_PERIOD || SEVEN_DAYS
+  DEFAULT_EXPIRATION_PERIOD:
+    process.env.DEFAULT_EXPIRATION_PERIOD || SEVEN_DAYS,
+  MAX_CLEANUP_RETRY: process.env.MAX_CLEANUP_RETRY || 10,
+  DELETE_INTERVAL
 };
 
 export default config;

--- a/src/data/DynamoDataModel.ts
+++ b/src/data/DynamoDataModel.ts
@@ -17,7 +17,8 @@ export const dynamoDataModel: dynogels.Model = dynogels.define(
       stackName: joi.string(),
       stackId: joi.string(),
       expirationTime: joi.number(),
-      tags: joi.string()
+      tags: joi.string(),
+      deleteCount: joi.number()
     }
   }
 );

--- a/src/handlers/deleteCloudFormationStack.test.ts
+++ b/src/handlers/deleteCloudFormationStack.test.ts
@@ -37,7 +37,8 @@ describe("deleteCloudFormationStack", () => {
               tags: {
                 S:
                   '[{"value":"your-app-name","key":"APP_NAME"},{"value":"4018","key":"BUILD_NUMBER"},{"value":"enabled","key":"stackjanitor"}]'
-              }
+              },
+              deleteCount: 0
             },
             StreamViewType: "NEW_AND_OLD_IMAGES"
           }

--- a/src/handlers/deleteCloudFormationStack.ts
+++ b/src/handlers/deleteCloudFormationStack.ts
@@ -88,7 +88,10 @@ async function processRecords(records: ParsedRecord<DataItem>[]) {
         record.oldData?.deleteCount &&
         record.oldData.deleteCount > config.MAX_CLEANUP_RETRY
       ) {
-        // TODO: Post a message / alert somewhere something placeholder
+        // Log message to cloudwatch
+        logger.error(
+          `Failed to delete stack after ${config.MAX_CLEANUP_RETRY} additional attempts: ${oldData.stackName}`
+        );
       } else {
         // Recreate record
         const deleteItem = generateRepeatedDeleteItem(oldData);

--- a/src/handlers/monitorCloudFormationStack.test.ts
+++ b/src/handlers/monitorCloudFormationStack.test.ts
@@ -98,6 +98,7 @@ describe("monitorCloudFormationStack:generateItemFromEvent", () => {
       }
     };
     expect(generateItemFromEvent(event)).toEqual({
+      deleteCount: 0,
       stackName: "CloudJanitorTest",
       stackId:
         "arn:aws:cloudformation:ap-southeast-2:12345:stack/CloudJanitorTest/e46581a0-ba48-11e9-a48c-0a4631dffc70",

--- a/src/handlers/monitorCloudFormationStack.ts
+++ b/src/handlers/monitorCloudFormationStack.ts
@@ -29,7 +29,23 @@ export const generateItemFromEvent = (event: CloudFormationEvent): DataItem => {
     stackName: event.detail.requestParameters.stackName,
     stackId: event.detail.responseElements.stackId,
     expirationTime: expirationTime,
-    tags: JSON.stringify(event.detail.requestParameters.tags)
+    tags: JSON.stringify(event.detail.requestParameters.tags),
+    deleteCount: 0
+  };
+};
+
+// Takes the old DataItem and creates a new one as a retry
+export const generateRepeatedDeleteItem = (oldItem: DataItem): DataItem => {
+  const deleteCount = oldItem.deleteCount ? oldItem.deleteCount + 1 : 1;
+  const newExpiration =
+    Math.floor(new Date().getTime() / 1000) +
+    config.DELETE_INTERVAL * deleteCount;
+  return {
+    stackName: oldItem.stackName,
+    stackId: oldItem.stackId,
+    expirationTime: newExpiration,
+    tags: oldItem.tags,
+    deleteCount
   };
 };
 

--- a/typings/stackjanitor.d.ts
+++ b/typings/stackjanitor.d.ts
@@ -18,6 +18,7 @@ declare module "stackjanitor" {
     stackId: string;
     stackName: string;
     tags: string;
+    deleteCount?: number;
   }
 
   export interface DeleteItem {


### PR DESCRIPTION
Adds retry behaviour and writes a new record to the DynamoDB table with the `deleteCount` incremented
Modify the serverless.yml file to better support multiple stackjanitor deployments in 1 AWS account