### PR TITLE
bump github actions plugins to v2, updates to release script

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
       with:
-        node-version: '10.x'
+        node-version: '12'
     - name: Build 👷‍♀️
       run: yarn
     - name: Lint 👮‍♀️

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
       with:
-        node-version: '10.x'
+        node-version: '12'
     - name: Build 👷‍♀️
       run: yarn
     - name: Lint 👮‍♀️

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,18 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
       with:
-        node-version: '10.x'
+        fetch-depth: 0 # Fetch all commits, assuming release-it needs this for the commit history
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12'
     - run: yarn
     - name: Release 🎉
       run:  |
-        git checkout master
-        git remote rm origin
-        git remote add origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-        git fetch
-        git config --global user.email octobot@github.com
-        git config --global user.name GitHub Actions
+        git config user.name github-actions
+        git config user.email github-actions@github.com
         yarn release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: DataDog Event Trigger
       uses: jordan-simonovski/datadog-event-action@1.0.3
       env:


### PR DESCRIPTION
Having a stab at fixing the release script - probably needs a bit of testing and massaging, but from what I've read this will *hopefully* do the trick.

Have also bumped the node versions to 12 in order to match the runtime being used in the Serverless deployment.