### PR TITLE
Update IAM Permissions to allow unsubscribing from SNS 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackjanitor",
-  "version": "1.35.0",
+  "version": "1.36.1",
   "description": "StackJanitor cleans up CloudFormation stacks based on TTL and tags.",
   "main": "src/handler.ts",
   "private": true,

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,7 @@ provider:
           - "s3:*"
           - "ecs:*"
           - "sqs:*"
+          - "sns:*"
           - "elasticloadbalancing:*"
           - "elasticloadbalancing:*"
           - "elasticloadbalancingv2:*"


### PR DESCRIPTION
When removing resources that have an SNS alert configured, StackJanitor does not have permissions to unsubscribe resulting in the stack failing to remove correctly. 